### PR TITLE
Add missing dependency

### DIFF
--- a/AcManager.sln
+++ b/AcManager.sln
@@ -286,7 +286,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {6414BBD0-671D-45D3-99B4-17943FB2FEB0}
 		RESX_SortFileContentOnSave = False
+		SolutionGuid = {6414BBD0-671D-45D3-99B4-17943FB2FEB0}
 	EndGlobalSection
 EndGlobal

--- a/FirstFloor.ModernUI/FirstFloor.ModernUI.csproj
+++ b/FirstFloor.ModernUI/FirstFloor.ModernUI.csproj
@@ -63,6 +63,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Blend.Interctivity.WPF.v4.0.1.0.3\lib\net40\Microsoft.Expression.Interactions.dll</HintPath>
+    </Reference>
     <Reference Include="SmartThreadPool">
       <HintPath>..\Libraries\SmartThreadPool\SmartThreadPool.dll</HintPath>
     </Reference>
@@ -83,7 +86,9 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Blend.Interctivity.WPF.v4.0.1.0.3\lib\net40\System.Windows.Interactivity.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/FirstFloor.ModernUI/packages.config
+++ b/FirstFloor.ModernUI/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Blend.Interctivity.WPF.v4.0" version="1.0.3" targetFramework="net452" />
   <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Without Blend Interctivity WPF the project did not successfully build.

Big thanks to @IgnasLabinas for helping me to dig to the bottom of this.

@gro-ove I assume you have "Blend Interctivity WPF" installed globally which is why it was not required in the build files in your system.