### PR TITLE
Fix codec URL when Windows Media Player cannot play a file

### DIFF
--- a/AcManager.Controls/Video/WindowsMediaPlayer.cs
+++ b/AcManager.Controls/Video/WindowsMediaPlayer.cs
@@ -39,11 +39,11 @@ namespace AcManager.Controls.Video {
             string url;
             var extension = Path.GetExtension(filename)?.Replace(@".", "").ToLowerInvariant();
             switch (extension) {
-                case ".ogv":
+                case "ogv":
                     url = @"https://xiph.org/dshow/";
                     break;
 
-                case ".webm":
+                case "webm":
                     url = @"https://tools.google.com/dlpage/webmmf/";
                     break;
 

--- a/AcManager.Tools.Tests/AcManager.Tools.Tests.csproj
+++ b/AcManager.Tools.Tests/AcManager.Tools.Tests.csproj
@@ -60,7 +60,7 @@
       <HintPath>..\Output\x86\Debug\AcTools.AcdEncryption.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\Output\x86\Debug\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\Libraries\Newtonsoft.Json\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
       <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>

--- a/AcManager.Tools.Tests/AcManager.Tools.Tests.csproj
+++ b/AcManager.Tools.Tests/AcManager.Tools.Tests.csproj
@@ -57,7 +57,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AcTools.AcdEncryption, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\Output\x86\Debug\AcTools.AcdEncryption.dll</HintPath>
+      <HintPath>..\Libraries\AcTools\AcTools.AcdEncryption.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\Libraries\Newtonsoft.Json\Newtonsoft.Json.dll</HintPath>

--- a/AcManager/AcManager.csproj
+++ b/AcManager/AcManager.csproj
@@ -127,7 +127,7 @@
       <HintPath>..\Libraries\AcTools\AcTools.AcdEncryption.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="AcTools.AcdEncryption, Culture=neutral">
+    <Reference Include="AcTools.Kn5Tools, Culture=neutral">
       <HintPath>..\Libraries\AcTools\AcTools.Kn5Tools.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>

--- a/AcTools.ExtraKn5Utils/AcTools.ExtraKn5Utils.csproj
+++ b/AcTools.ExtraKn5Utils/AcTools.ExtraKn5Utils.csproj
@@ -61,7 +61,7 @@
       <HintPath>..\packages\JetBrains.Annotations.10.4.0\lib\net\JetBrains.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\Output\x86\Debug\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\Libraries\Newtonsoft.Json\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SlimDX, Culture=neutral, processorArchitecture=$(ActualPlatform)">
       <HintPath>..\Libraries\SlimDX-$(ActualPlatform)\SlimDX.dll</HintPath>


### PR DESCRIPTION
When Windows Media Player cannot play a file, the URL to find codecs is incorrect since extension matching is correct.

This PR addresses this by modifying the `switch` cases to correctly match the extension. Additionally, it fixes a compilation error due to an incorrect reference to `Newtonsoft.Json`.