### PR TITLE
Add progress dialog and automatic rejoin for server-driven content installs

### DIFF
--- a/AcManager.Tools/ContentInstallation/ContentInstallationEntry.cs
+++ b/AcManager.Tools/ContentInstallation/ContentInstallationEntry.cs
@@ -368,6 +368,15 @@ namespace AcManager.Tools.ContentInstallation {
         public DelegateCommand ConfirmCommand
             => _confirmCommand ?? (_confirmCommand = new DelegateCommand(() => { Confirm?.Invoke(this, EventArgs.Empty); }, () => WaitingForConfirmation));
 
+        private bool ShouldAutoConfirmServerInstall() {
+            if (!InstallationParams.AutoConfirmServerInstall) return false;
+            var entries = Entries;
+            if (entries == null || entries.Length == 0) return false;
+            var active = entries.Where(x => x.Active).ToList();
+            if (active.Count == 0) return false;
+            return active.All(x => x is CarContentEntry || x is TrackContentEntry);
+        }
+
         private Task WaitForConfirmation() {
             var tcs = new TaskCompletionSource<bool>();
             _cancellationTokenSource?.Token.Register(() => tcs.TrySetCanceled());
@@ -753,7 +762,11 @@ namespace AcManager.Tools.ContentInstallation {
                             if (CheckCancellation()) return false;
 
                             _taskbar?.Set(TaskbarState.Paused, 0d);
-                            await WaitForConfirmation();
+                            if (ShouldAutoConfirmServerInstall()) {
+                                Logging.Debug("Server-driven install: auto-confirming car/track content");
+                            } else {
+                                await WaitForConfirmation();
+                            }
                             if (CheckCancellation()) return false;
 
                             _taskbar?.Set(TaskbarState.Indeterminate, 0d);

--- a/AcManager.Tools/ContentInstallation/ContentInstallationEntry.cs
+++ b/AcManager.Tools/ContentInstallation/ContentInstallationEntry.cs
@@ -370,6 +370,7 @@ namespace AcManager.Tools.ContentInstallation {
 
         private bool ShouldAutoConfirmServerInstall() {
             if (!InstallationParams.AutoConfirmServerInstall) return false;
+            if (!SettingsHolder.Content.ServerDownloadsAutoConfirm) return false;
             var entries = Entries;
             if (entries == null || entries.Length == 0) return false;
             var active = entries.Where(x => x.Active).ToList();

--- a/AcManager.Tools/ContentInstallation/ContentInstallationManager.cs
+++ b/AcManager.Tools/ContentInstallation/ContentInstallationManager.cs
@@ -177,6 +177,27 @@ namespace AcManager.Tools.ContentInstallation {
             set => Apply(value, ref _hasLoadingItems);
         }
 
+        private bool _postInstallAutoJoinActive;
+
+        public bool PostInstallAutoJoinActive {
+            get => _postInstallAutoJoinActive;
+            private set => Apply(value, ref _postInstallAutoJoinActive);
+        }
+
+        private bool _postInstallAutoJoinFailed;
+
+        public bool PostInstallAutoJoinFailed {
+            get => _postInstallAutoJoinFailed;
+            private set => Apply(value, ref _postInstallAutoJoinFailed);
+        }
+
+        private string _postInstallAutoJoinMessage;
+
+        public string PostInstallAutoJoinMessage {
+            get => _postInstallAutoJoinMessage;
+            private set => Apply(value, ref _postInstallAutoJoinMessage);
+        }
+
         private int _unfinishedItemsCount;
 
         public int UnfinishedItemsCount {
@@ -190,6 +211,16 @@ namespace AcManager.Tools.ContentInstallation {
         }
 
         public bool HasUnfinishedItems => _unfinishedItemsCount > 0;
+
+        public void SetPostInstallAutoJoinState([CanBeNull] string message, bool failed = false) {
+            PostInstallAutoJoinMessage = message;
+            PostInstallAutoJoinFailed = failed;
+            PostInstallAutoJoinActive = !string.IsNullOrWhiteSpace(message);
+        }
+
+        public void ClearPostInstallAutoJoinState() {
+            SetPostInstallAutoJoinState(null);
+        }
 
         public void UpdateBusyStates() {
             var hasLoadingItems = false;

--- a/AcManager.Tools/ContentInstallation/ContentInstallationParams.cs
+++ b/AcManager.Tools/ContentInstallation/ContentInstallationParams.cs
@@ -53,6 +53,14 @@ namespace AcManager.Tools.ContentInstallation {
 
         public bool SyncDetails { get; set; }
 
+        /// <summary>
+        /// If set, installation will skip the manual confirmation step when the
+        /// detected content is limited to cars and/or tracks. Used by server-driven
+        /// installs (e.g. acmanager://install?autoconfirm=1) so the player doesn't
+        /// have to interact with CM after a server hand-off.
+        /// </summary>
+        public bool AutoConfirmServerInstall { get; set; }
+
         public async Task PostInstallation(IProgress<AsyncProgressEntry> progress, CancellationToken token) {
             if (!CupType.HasValue || IdsToUpdate == null) return;
 

--- a/AcManager.Tools/Helpers/SettingsHolder.Content.cs
+++ b/AcManager.Tools/Helpers/SettingsHolder.Content.cs
@@ -306,6 +306,19 @@ namespace AcManager.Tools.Helpers {
 
             public string TemporaryFilesLocationValue => TemporaryFilesLocation == "" ? Path.GetTempPath() : TemporaryFilesLocation;
 
+            private bool? _serverDownloadsAutoConfirm;
+
+            public bool ServerDownloadsAutoConfirm {
+                get => _serverDownloadsAutoConfirm ??
+                        (_serverDownloadsAutoConfirm = ValuesStorage.Get("Settings.ContentSettings.ServerDownloadsAutoConfirm", true)).Value;
+                set {
+                    if (Equals(value, _serverDownloadsAutoConfirm)) return;
+                    _serverDownloadsAutoConfirm = value;
+                    ValuesStorage.Set("Settings.ContentSettings.ServerDownloadsAutoConfirm", value);
+                    OnPropertyChanged();
+                }
+            }
+
             private string _fontIconCharacter;
 
             public string FontIconCharacter {

--- a/AcManager/AcManager.csproj
+++ b/AcManager/AcManager.csproj
@@ -467,6 +467,9 @@
     <Compile Include="Pages\Dialogs\GameDialog.xaml.cs">
       <DependentUpon>GameDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Pages\Dialogs\ServerInstallProgressDialog.xaml.cs">
+      <DependentUpon>ServerInstallProgressDialog.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Pages\Dialogs\LiveryIconEditorDialog.xaml.cs">
       <DependentUpon>LiveryIconEditorDialog.xaml</DependentUpon>
     </Compile>
@@ -1206,6 +1209,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Pages\Dialogs\GameDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Pages\Dialogs\ServerInstallProgressDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/AcManager/AppStrings.Designer.cs
+++ b/AcManager/AppStrings.Designer.cs
@@ -4757,6 +4757,33 @@ namespace AcManager {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Waiting for confirmation.
+        /// </summary>
+        public static string ServerInstallProgress_WaitingForConfirmation {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_WaitingForConfirmation", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Downloads that are not cars or tracks are not auto-confirmed to ensure safety. If you want to install this content, click Confirm..
+        /// </summary>
+        public static string ServerInstallProgress_ManualConfirmationWarning {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_ManualConfirmationWarning", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Confirm.
+        /// </summary>
+        public static string ServerInstallProgress_Confirm {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_Confirm", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Password required (resolve in downloads panel).
         /// </summary>
         public static string ServerInstallProgress_PasswordRequired {

--- a/AcManager/AppStrings.Designer.cs
+++ b/AcManager/AppStrings.Designer.cs
@@ -4584,6 +4584,222 @@ namespace AcManager {
                 return ResourceManager.GetString("DownloadList_NoActiveDownloads", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Automatic rejoin enabled.
+        /// </summary>
+        public static string Arguments_AutoRejoinEnabled_Title {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinEnabled_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to You'll be reconnected automatically when installation finishes..
+        /// </summary>
+        public static string Arguments_AutoRejoinEnabled_Message {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinEnabled_Message", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to You'll be reconnected automatically when installation finishes..
+        /// </summary>
+        public static string Arguments_AutoRejoinEnabled_State {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinEnabled_State", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Automatic rejoin skipped.
+        /// </summary>
+        public static string Arguments_AutoRejoinSkipped_Title {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinSkipped_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Missing server, car, or skin details. Content will still be installed..
+        /// </summary>
+        public static string Arguments_AutoRejoinSkipped_Message {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinSkipped_Message", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Automatic rejoin was skipped because server, car, or skin details are missing..
+        /// </summary>
+        public static string Arguments_AutoRejoinSkipped_State {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinSkipped_State", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Automatic rejoin cancelled.
+        /// </summary>
+        public static string Arguments_AutoRejoinCancelled_Title {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinCancelled_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to One or more downloads failed or were cancelled..
+        /// </summary>
+        public static string Arguments_AutoRejoinCancelled_Message {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinCancelled_Message", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Automatic rejoin was cancelled because one or more downloads failed or were cancelled..
+        /// </summary>
+        public static string Arguments_AutoRejoinCancelled_State {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinCancelled_State", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Installation finished. Rejoining server….
+        /// </summary>
+        public static string Arguments_AutoRejoinRejoining_State {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinRejoining_State", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Installation finished. Rejoined the server..
+        /// </summary>
+        public static string Arguments_AutoRejoinRejoined_State {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinRejoined_State", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Reconnected.
+        /// </summary>
+        public static string Arguments_AutoRejoinReconnected_Title {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinReconnected_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Content finished installing and CM rejoined the server..
+        /// </summary>
+        public static string Arguments_AutoRejoinReconnected_Message {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinReconnected_Message", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Installation finished, but automatic rejoin failed. Check the downloads panel for details..
+        /// </summary>
+        public static string Arguments_AutoRejoinFailed_State {
+            get {
+                return ResourceManager.GetString("Arguments_AutoRejoinFailed_State", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Server install.
+        /// </summary>
+        public static string ServerInstallProgress_HeaderTitle {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_HeaderTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Installing content.
+        /// </summary>
+        public static string ServerInstallProgress_HeaderTitleInstalling {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_HeaderTitleInstalling", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to You'll be reconnected automatically when this finishes..
+        /// </summary>
+        public static string ServerInstallProgress_HeaderMessageRejoin {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_HeaderMessageRejoin", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This will close once it's done..
+        /// </summary>
+        public static string ServerInstallProgress_HeaderMessageAutoClose {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_HeaderMessageAutoClose", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Downloading….
+        /// </summary>
+        public static string ServerInstallProgress_HeaderMessageDownloading {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_HeaderMessageDownloading", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Password required (resolve in downloads panel).
+        /// </summary>
+        public static string ServerInstallProgress_PasswordRequired {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_PasswordRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Installed..
+        /// </summary>
+        public static string ServerInstallProgress_Installed {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_Installed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to One or more downloads failed. Check the downloads panel for details..
+        /// </summary>
+        public static string ServerInstallProgress_FailureSummary {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_FailureSummary", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Done..
+        /// </summary>
+        public static string ServerInstallProgress_Done {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_Done", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Done — reconnecting….
+        /// </summary>
+        public static string ServerInstallProgress_DoneReconnecting {
+            get {
+                return ResourceManager.GetString("ServerInstallProgress_DoneReconnecting", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Nothing found.

--- a/AcManager/AppStrings.resx
+++ b/AcManager/AppStrings.resx
@@ -4899,6 +4899,78 @@ Content Manager [url="/Pages/About/License.xaml|_top"]License[/url].</value>
     <data name="DownloadList_NoActiveDownloads" xml:space="preserve">
         <value>No active downloads</value>
     </data>
+    <data name="Arguments_AutoRejoinEnabled_Title" xml:space="preserve">
+        <value>Automatic rejoin enabled</value>
+    </data>
+    <data name="Arguments_AutoRejoinEnabled_Message" xml:space="preserve">
+        <value>You'll be reconnected automatically when installation finishes.</value>
+    </data>
+    <data name="Arguments_AutoRejoinEnabled_State" xml:space="preserve">
+        <value>You'll be reconnected automatically when installation finishes.</value>
+    </data>
+    <data name="Arguments_AutoRejoinSkipped_Title" xml:space="preserve">
+        <value>Automatic rejoin skipped</value>
+    </data>
+    <data name="Arguments_AutoRejoinSkipped_Message" xml:space="preserve">
+        <value>Missing server, car, or skin details. Content will still be installed.</value>
+    </data>
+    <data name="Arguments_AutoRejoinSkipped_State" xml:space="preserve">
+        <value>Automatic rejoin was skipped because server, car, or skin details are missing.</value>
+    </data>
+    <data name="Arguments_AutoRejoinCancelled_Title" xml:space="preserve">
+        <value>Automatic rejoin cancelled</value>
+    </data>
+    <data name="Arguments_AutoRejoinCancelled_Message" xml:space="preserve">
+        <value>One or more downloads failed or were cancelled.</value>
+    </data>
+    <data name="Arguments_AutoRejoinCancelled_State" xml:space="preserve">
+        <value>Automatic rejoin was cancelled because one or more downloads failed or were cancelled.</value>
+    </data>
+    <data name="Arguments_AutoRejoinRejoining_State" xml:space="preserve">
+        <value>Installation finished. Rejoining server…</value>
+    </data>
+    <data name="Arguments_AutoRejoinRejoined_State" xml:space="preserve">
+        <value>Installation finished. Rejoined the server.</value>
+    </data>
+    <data name="Arguments_AutoRejoinReconnected_Title" xml:space="preserve">
+        <value>Reconnected</value>
+    </data>
+    <data name="Arguments_AutoRejoinReconnected_Message" xml:space="preserve">
+        <value>Content finished installing and CM rejoined the server.</value>
+    </data>
+    <data name="Arguments_AutoRejoinFailed_State" xml:space="preserve">
+        <value>Installation finished, but automatic rejoin failed. Check the downloads panel for details.</value>
+    </data>
+    <data name="ServerInstallProgress_HeaderTitle" xml:space="preserve">
+        <value>Server install</value>
+    </data>
+    <data name="ServerInstallProgress_HeaderTitleInstalling" xml:space="preserve">
+        <value>Installing content</value>
+    </data>
+    <data name="ServerInstallProgress_HeaderMessageRejoin" xml:space="preserve">
+        <value>You'll be reconnected automatically when this finishes.</value>
+    </data>
+    <data name="ServerInstallProgress_HeaderMessageAutoClose" xml:space="preserve">
+        <value>This will close once it's done.</value>
+    </data>
+    <data name="ServerInstallProgress_HeaderMessageDownloading" xml:space="preserve">
+        <value>Downloading…</value>
+    </data>
+    <data name="ServerInstallProgress_PasswordRequired" xml:space="preserve">
+        <value>Password required (resolve in downloads panel)</value>
+    </data>
+    <data name="ServerInstallProgress_Installed" xml:space="preserve">
+        <value>Installed.</value>
+    </data>
+    <data name="ServerInstallProgress_FailureSummary" xml:space="preserve">
+        <value>One or more downloads failed. Check the downloads panel for details.</value>
+    </data>
+    <data name="ServerInstallProgress_Done" xml:space="preserve">
+        <value>Done.</value>
+    </data>
+    <data name="ServerInstallProgress_DoneReconnecting" xml:space="preserve">
+        <value>Done — reconnecting…</value>
+    </data>
     <data name="Arguments_SharedMessage_LocalSource" xml:space="preserve">
         <value>Name: [b]{0}[/b]</value>
         <comment>Shown when .cmpreset files are being opened</comment>

--- a/AcManager/AppStrings.resx
+++ b/AcManager/AppStrings.resx
@@ -4956,6 +4956,15 @@ Content Manager [url="/Pages/About/License.xaml|_top"]License[/url].</value>
     <data name="ServerInstallProgress_HeaderMessageDownloading" xml:space="preserve">
         <value>Downloading…</value>
     </data>
+    <data name="ServerInstallProgress_WaitingForConfirmation" xml:space="preserve">
+        <value>Waiting for confirmation</value>
+    </data>
+    <data name="ServerInstallProgress_ManualConfirmationWarning" xml:space="preserve">
+        <value>Downloads that are not cars or tracks are not auto-confirmed to ensure safety. If you want to install this content, click Confirm.</value>
+    </data>
+    <data name="ServerInstallProgress_Confirm" xml:space="preserve">
+        <value>Confirm</value>
+    </data>
     <data name="ServerInstallProgress_PasswordRequired" xml:space="preserve">
         <value>Password required (resolve in downloads panel)</value>
     </data>

--- a/AcManager/Pages/Dialogs/GameDialog.xaml.cs
+++ b/AcManager/Pages/Dialogs/GameDialog.xaml.cs
@@ -80,6 +80,16 @@ namespace AcManager.Pages.Dialogs {
         public static bool OptionHideCancelButton = false;
         public static bool OptionSkipAllResults = false;
 
+        /// <summary>
+        /// One-shot suppression: when set to a future timestamp, the next call to
+        /// <see cref="OnResult"/> will skip showing the results dialog and the
+        /// flag is then cleared. Used by server-driven content handoffs (see
+        /// acmanager://install?rejoin=1) to avoid flashing a meaningless
+        /// "Practice / Try again / Replay" window after AC closes for the install.
+        /// Auto-expires so a stale flag never swallows a legit race result.
+        /// </summary>
+        public static DateTime SkipNextResultUntil = DateTime.MinValue;
+
         public const int DefinitelyNonPrizePlace = 99999;
         private static GoodShuffle<string> _progressStyles;
 
@@ -689,6 +699,24 @@ namespace AcManager.Pages.Dialogs {
         public void OnResult(Game.Result result, ReplayHelper replayHelper) {
             RevertSizeFix().Ignore();
 
+            // Consume the one-shot suppression flag up-front so it can't be bypassed by
+            // any of the early-return branches below (e.g. benchmark/FPS-replay results).
+            // Replay/results-viewer mode (_resultsViewMode) must NOT honour or consume
+            // the flag, otherwise opening a saved result right after a rejoin handoff
+            // would silently close the viewer.
+            var skipNextOneShot = false;
+            if (!_resultsViewMode) {
+                skipNextOneShot = SkipNextResultUntil > DateTime.UtcNow;
+                if (SkipNextResultUntil != DateTime.MinValue) {
+                    if (skipNextOneShot) {
+                        Logging.Debug($"GameDialog: SkipNextResultUntil consumed (flag was {SkipNextResultUntil:O})");
+                    } else {
+                        Logging.Debug($"GameDialog: SkipNextResultUntil expired (flag was {SkipNextResultUntil:O}), clearing");
+                    }
+                    SkipNextResultUntil = DateTime.MinValue;
+                }
+            }
+
             if (SettingsHolder.Drive.WatchForSharedMemory) {
                 AcSharedMemory.Instance.MonitorFramesPerSecond = false;
             }
@@ -714,9 +742,10 @@ namespace AcManager.Pages.Dialogs {
                 }
             }
 
-            var skipResults = OptionSkipAllResults || (_properties?.ReplayProperties != null || _properties?.BenchmarkProperties != null
-                    ? _properties?.GetAdditional<WhatsGoingOn>() == null
-                    : !_resultsViewMode && _properties != null && SettingsHolder.Drive.SkipResults(result, _properties));
+            var skipResults = OptionSkipAllResults || skipNextOneShot
+                    || (_properties?.ReplayProperties != null || _properties?.BenchmarkProperties != null
+                            ? _properties?.GetAdditional<WhatsGoingOn>() == null
+                            : !_resultsViewMode && _properties != null && SettingsHolder.Drive.SkipResults(result, _properties));
             if (skipResults) {
                 if (IsLoaded) {
                     Close();

--- a/AcManager/Pages/Dialogs/ServerInstallProgressDialog.xaml
+++ b/AcManager/Pages/Dialogs/ServerInstallProgressDialog.xaml
@@ -3,7 +3,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mui="http://firstfloorsoftware.com/ModernUI"
     xmlns:presentation="clr-namespace:FirstFloor.ModernUI.Presentation;assembly=FirstFloor.ModernUI" xmlns:di="clr-namespace:AcManager.Pages.Dialogs"
     xmlns:g="clr-namespace:AcManager"
-    xmlns:t="http://acstuff.club/app/tools" mc:Ignorable="d" Width="480" SizeToContent="Height" MinHeight="40" MaxHeight="640" Padding="24 20 24 0"
+    xmlns:t="http://acstuff.club/app/tools" mc:Ignorable="d" Width="480" SizeToContent="Height" MinHeight="40" MaxHeight="640" Padding="24 20 24 12"
     WindowStyle="None" AllowsTransparency="True" ShowInTaskbar="False" ShowTitle="False" ShowTopBlob="False"
     d:DataContext="{d:DesignInstance di:ServerInstallProgressDialog+ViewModel}">
   <mui:ModernDialog.Resources>
@@ -50,7 +50,11 @@
                 <TextBlock Text="{x:Static g:AppStrings.ServerInstallProgress_PasswordRequired}" Style="{StaticResource Small}" TextTrimming="CharacterEllipsis" />
               </DockPanel>
 
-              <ProgressBar mui:Switch.When="{x:Static t:ContentInstallationEntryState.WaitingForConfirmation}" Maximum="1" IsIndeterminate="True" Height="6" />
+              <DockPanel mui:Switch.When="{x:Static t:ContentInstallationEntryState.WaitingForConfirmation}">
+                <Path Data="{StaticResource AlertIconData}" Width="12" Height="12" DockPanel.Dock="Left" Fill="{DynamicResource Accent}" Stretch="Uniform"
+                    Margin="0 1 4 -1" VerticalAlignment="Center" />
+                <TextBlock Text="{x:Static g:AppStrings.ServerInstallProgress_WaitingForConfirmation}" Style="{StaticResource Small}" TextTrimming="CharacterEllipsis" />
+              </DockPanel>
 
               <mui:ReferenceSwitch mui:Switch.When="{x:Static t:ContentInstallationEntryState.Finished}" Value="{Binding FailedMessage}">
                 <mui:ReferenceSwitch.Null>
@@ -81,6 +85,8 @@
             Fill="{DynamicResource Go}" Stretch="Uniform" />
         <Path mui:Switch.When="{x:Static di:ServerInstallProgressDialog+StatusKindValue.Failure}" Data="{StaticResource AlertIconData}" Width="12" Height="12"
             Fill="{DynamicResource Error}" Stretch="Uniform" />
+        <Path mui:Switch.When="{x:Static di:ServerInstallProgressDialog+StatusKindValue.Warning}" Data="{StaticResource AlertIconData}" Width="12" Height="12"
+            Fill="{DynamicResource Accent}" Stretch="Uniform" />
       </mui:Switch>
       <mui:BbCodeBlock Text="{Binding StatusMessage}" Style="{StaticResource Small}" TextWrapping="Wrap" />
     </DockPanel>

--- a/AcManager/Pages/Dialogs/ServerInstallProgressDialog.xaml
+++ b/AcManager/Pages/Dialogs/ServerInstallProgressDialog.xaml
@@ -1,0 +1,88 @@
+<mui:ModernDialog x:Class="AcManager.Pages.Dialogs.ServerInstallProgressDialog" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mui="http://firstfloorsoftware.com/ModernUI"
+    xmlns:presentation="clr-namespace:FirstFloor.ModernUI.Presentation;assembly=FirstFloor.ModernUI" xmlns:di="clr-namespace:AcManager.Pages.Dialogs"
+    xmlns:g="clr-namespace:AcManager"
+    xmlns:t="http://acstuff.club/app/tools" mc:Ignorable="d" Width="480" SizeToContent="Height" MinHeight="40" MaxHeight="640" Padding="24 20 24 0"
+    WindowStyle="None" AllowsTransparency="True" ShowInTaskbar="False" ShowTitle="False" ShowTopBlob="False"
+    d:DataContext="{d:DesignInstance di:ServerInstallProgressDialog+ViewModel}">
+  <mui:ModernDialog.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <presentation:SharedResourceDictionary Source="/FirstFloor.ModernUI;component/Assets/Converters.xaml" />
+        <presentation:SharedResourceDictionary Source="/FirstFloor.ModernUI;component/Assets/TextBlock.xaml" />
+        <mui:SharedResourceDictionary Source="/AcManager.Controls;component/Assets/IconData.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </mui:ModernDialog.Resources>
+
+  <mui:SpacingStackPanel Spacing="16">
+    <DockPanel>
+      <mui:ModernProgressRing DockPanel.Dock="Left" IsActive="{Binding IsRingActive}" Width="32" Height="32" Margin="0 0 14 0" VerticalAlignment="Center" />
+      <mui:SpacingStackPanel Spacing="2" VerticalAlignment="Center">
+        <TextBlock Text="{Binding HeaderTitle}" Style="{StaticResource Title}" />
+        <mui:BbCodeBlock Text="{Binding HeaderMessage}" Style="{StaticResource Small}" TextWrapping="Wrap" />
+      </mui:SpacingStackPanel>
+    </DockPanel>
+
+    <ItemsControl ItemsSource="{Binding Entries}">
+      <ItemsControl.ItemsPanel>
+        <ItemsPanelTemplate>
+          <mui:SpacingStackPanel Spacing="12" />
+        </ItemsPanelTemplate>
+      </ItemsControl.ItemsPanel>
+      <ItemsControl.ItemTemplate>
+        <DataTemplate DataType="t:ContentInstallationEntry">
+          <DockPanel>
+            <DockPanel DockPanel.Dock="Top">
+              <TextBlock DockPanel.Dock="Right" Style="{StaticResource Label}" Margin="8 1 0 0" Text="{Binding Progress.Message}"
+                  Visibility="{Binding Progress.Message, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=inverse}" />
+              <TextBlock Text="{Binding DisplayName}" Style="{StaticResource Heading2}" TextTrimming="CharacterEllipsis" />
+            </DockPanel>
+
+            <mui:Switch Value="{Binding State}" Margin="0 6 0 0">
+              <ProgressBar mui:Switch.When="{x:Static t:ContentInstallationEntryState.Loading}" Maximum="1" Value="{Binding Progress.Progress, Mode=OneWay}"
+                  IsIndeterminate="{Binding Progress.IsIndeterminate}" Height="6" />
+
+              <DockPanel mui:Switch.When="{x:Static t:ContentInstallationEntryState.PasswordRequired}">
+                <Path Data="{StaticResource AlertIconData}" Width="12" Height="12" DockPanel.Dock="Left" Fill="{DynamicResource Error}" Stretch="Uniform"
+                    Margin="0 1 4 -1" VerticalAlignment="Center" />
+                <TextBlock Text="{x:Static g:AppStrings.ServerInstallProgress_PasswordRequired}" Style="{StaticResource Small}" TextTrimming="CharacterEllipsis" />
+              </DockPanel>
+
+              <ProgressBar mui:Switch.When="{x:Static t:ContentInstallationEntryState.WaitingForConfirmation}" Maximum="1" IsIndeterminate="True" Height="6" />
+
+              <mui:ReferenceSwitch mui:Switch.When="{x:Static t:ContentInstallationEntryState.Finished}" Value="{Binding FailedMessage}">
+                <mui:ReferenceSwitch.Null>
+                  <DockPanel>
+                    <Path Data="{StaticResource CheckIconData}" Width="12" Height="12" DockPanel.Dock="Left" Fill="{DynamicResource Go}" Stretch="Uniform"
+                        Margin="0 1 4 -1" VerticalAlignment="Center" />
+                    <TextBlock Text="{x:Static g:AppStrings.ServerInstallProgress_Installed}" Style="{StaticResource Small}" Foreground="{DynamicResource Go}" TextTrimming="CharacterEllipsis" />
+                  </DockPanel>
+                </mui:ReferenceSwitch.Null>
+                <mui:ReferenceSwitch.NonNull>
+                  <DockPanel>
+                    <Path Data="{StaticResource AlertIconData}" Width="12" Height="12" DockPanel.Dock="Left" Fill="{DynamicResource Error}" Stretch="Uniform"
+                        Margin="0 1 4 -1" VerticalAlignment="Center" />
+                    <TextBlock Text="{Binding FailedMessage}" Style="{StaticResource Small}" Foreground="{DynamicResource Error}" TextTrimming="CharacterEllipsis"
+                        ToolTip="{Binding FailedMessage}" />
+                  </DockPanel>
+                </mui:ReferenceSwitch.NonNull>
+              </mui:ReferenceSwitch>
+            </mui:Switch>
+          </DockPanel>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+
+    <DockPanel Visibility="{Binding StatusMessage, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=inverse}">
+      <mui:Switch DockPanel.Dock="Left" Value="{Binding StatusKind}" VerticalAlignment="Center" Margin="0 1 6 -1">
+        <Path mui:Switch.When="{x:Static di:ServerInstallProgressDialog+StatusKindValue.Success}" Data="{StaticResource CheckIconData}" Width="12" Height="12"
+            Fill="{DynamicResource Go}" Stretch="Uniform" />
+        <Path mui:Switch.When="{x:Static di:ServerInstallProgressDialog+StatusKindValue.Failure}" Data="{StaticResource AlertIconData}" Width="12" Height="12"
+            Fill="{DynamicResource Error}" Stretch="Uniform" />
+      </mui:Switch>
+      <mui:BbCodeBlock Text="{Binding StatusMessage}" Style="{StaticResource Small}" TextWrapping="Wrap" />
+    </DockPanel>
+  </mui:SpacingStackPanel>
+</mui:ModernDialog>

--- a/AcManager/Pages/Dialogs/ServerInstallProgressDialog.xaml.cs
+++ b/AcManager/Pages/Dialogs/ServerInstallProgressDialog.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Controls;
 using AcManager.Tools.ContentInstallation;
 using FirstFloor.ModernUI;
+using FirstFloor.ModernUI.Commands;
 using FirstFloor.ModernUI.Helpers;
 using FirstFloor.ModernUI.Presentation;
 using FirstFloor.ModernUI.Windows.Controls;
@@ -23,6 +24,7 @@ namespace AcManager.Pages.Dialogs {
     public partial class ServerInstallProgressDialog : ModernDialog {
         public enum StatusKindValue {
             None,
+            Warning,
             Success,
             Failure
         }
@@ -149,15 +151,38 @@ namespace AcManager.Pages.Dialogs {
             }
         }
 
+        private IEnumerable<ContentInstallationEntry> TrackedEntries => _installationManager.DownloadList.Where(MatchesEntry);
+
+        private IEnumerable<ContentInstallationEntry> WaitingEntries => _model.Entries.Where(x => x.WaitingForConfirmation);
+
         private Control[] CreateWorkingButtons() {
             return new Control[] {
                     CreateExtraDialogButton(UiStrings.Toolbar_Hide, Close),
                     CreateExtraDialogButton(AppStrings.DownloadList_Cancel, () => {
-                        foreach (var entry in _installationManager.DownloadList.Where(MatchesEntry).ToList()) {
+                        foreach (var entry in TrackedEntries.ToList()) {
                             entry.CancelCommand.Execute();
                         }
                         Close();
                     })
+            };
+        }
+
+        private Control[] CreateConfirmationButtons() {
+            return new Control[] {
+                    CreateExtraDialogButton(UiStrings.Toolbar_Hide, Close),
+                    CreateExtraDialogButton(AppStrings.DownloadList_Cancel, () => {
+                        foreach (var entry in TrackedEntries.ToList()) {
+                            entry.CancelCommand.Execute();
+                        }
+                        Close();
+                    }),
+                    CreateExtraDialogButton(AppStrings.ServerInstallProgress_Confirm, new DelegateCommand(() => {
+                        foreach (var entry in WaitingEntries.ToList()) {
+                            if (entry.ConfirmCommand.IsAbleToExecute) {
+                                entry.ConfirmCommand.Execute();
+                            }
+                        }
+                    }, () => WaitingEntries.Any()), true)
             };
         }
 
@@ -181,8 +206,17 @@ namespace AcManager.Pages.Dialogs {
             if (_userClosed) return;
 
             var entries = _model.Entries;
+            var waitingForConfirmation = WaitingEntries.ToList();
             var anyActive = entries.Count == 0 || entries.Any(x => x.State != ContentInstallationEntryState.Finished);
             var anyFailed = entries.Any(x => x.State == ContentInstallationEntryState.Finished && !string.IsNullOrEmpty(x.FailedMessage));
+
+            if (waitingForConfirmation.Count > 0) {
+                _model.IsRingActive = false;
+                _model.StatusKind = StatusKindValue.Warning;
+                _model.StatusMessage = AppStrings.ServerInstallProgress_ManualConfirmationWarning;
+                Buttons = CreateConfirmationButtons();
+                return;
+            }
 
             if (anyActive) {
                 _model.IsRingActive = true;

--- a/AcManager/Pages/Dialogs/ServerInstallProgressDialog.xaml.cs
+++ b/AcManager/Pages/Dialogs/ServerInstallProgressDialog.xaml.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using AcManager.Tools.ContentInstallation;
+using FirstFloor.ModernUI;
+using FirstFloor.ModernUI.Helpers;
+using FirstFloor.ModernUI.Presentation;
+using FirstFloor.ModernUI.Windows.Controls;
+
+namespace AcManager.Pages.Dialogs {
+    /// <summary>
+    /// Modal popup shown to the player while a server-driven content install
+    /// (auto-confirm and/or auto-rejoin) runs. Mirrors the per-entry rows from
+    /// the downloads panel but in a small focused window so the player can see
+    /// what's happening without hunting through CM. Disappears as soon as the
+    /// installs finish so the rejoin handoff isn't blocked by a leftover dialog.
+    /// </summary>
+    public partial class ServerInstallProgressDialog : ModernDialog {
+        public enum StatusKindValue {
+            None,
+            Success,
+            Failure
+        }
+
+        public class ViewModel : NotifyPropertyChanged {
+            public BetterObservableCollection<ContentInstallationEntry> Entries { get; }
+                    = new BetterObservableCollection<ContentInstallationEntry>();
+
+            private string _headerTitle;
+            public string HeaderTitle {
+                get => _headerTitle;
+                set => Apply(value, ref _headerTitle);
+            }
+
+            private string _headerMessage;
+            public string HeaderMessage {
+                get => _headerMessage;
+                set => Apply(value, ref _headerMessage);
+            }
+
+            private string _statusMessage;
+            public string StatusMessage {
+                get => _statusMessage;
+                set => Apply(value, ref _statusMessage);
+            }
+
+            private StatusKindValue _statusKind = StatusKindValue.None;
+            public StatusKindValue StatusKind {
+                get => _statusKind;
+                set => Apply(value, ref _statusKind);
+            }
+
+            private bool _isRingActive = true;
+            public bool IsRingActive {
+                get => _isRingActive;
+                set => Apply(value, ref _isRingActive);
+            }
+        }
+
+        private readonly ViewModel _model;
+        private readonly HashSet<string> _trackedSources;
+        private readonly DateTime _trackedEntriesCreatedAfter;
+        private readonly bool _rejoinRequested;
+        private readonly ContentInstallationManager _installationManager = ContentInstallationManager.Instance;
+        private readonly HashSet<ContentInstallationEntry> _subscribed = new HashSet<ContentInstallationEntry>();
+        private bool _autoCloseScheduled;
+        private bool _userClosed;
+
+        public ServerInstallProgressDialog(IEnumerable<string> sources, bool rejoinRequested, bool autoConfirm, DateTime trackedEntriesCreatedAfter) {
+            _trackedSources = new HashSet<string>(sources ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            _trackedEntriesCreatedAfter = trackedEntriesCreatedAfter;
+            _rejoinRequested = rejoinRequested;
+            _model = new ViewModel {
+                HeaderTitle = rejoinRequested ? AppStrings.ServerInstallProgress_HeaderTitle : AppStrings.ServerInstallProgress_HeaderTitleInstalling,
+                HeaderMessage = rejoinRequested
+                        ? AppStrings.ServerInstallProgress_HeaderMessageRejoin
+                        : autoConfirm
+                                ? AppStrings.ServerInstallProgress_HeaderMessageAutoClose
+                                : AppStrings.ServerInstallProgress_HeaderMessageDownloading
+            };
+            DataContext = _model;
+            InitializeComponent();
+
+            Buttons = CreateWorkingButtons();
+
+            if (Application.Current?.MainWindow is Window owner && owner.IsLoaded && owner != this) {
+                Owner = owner;
+            }
+
+            Loaded += OnLoaded;
+            Closed += OnClosed;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e) {
+            _installationManager.DownloadList.CollectionChanged += OnDownloadListChanged;
+            _installationManager.PropertyChanged += OnInstallationManagerPropertyChanged;
+
+            foreach (var entry in _installationManager.DownloadList) {
+                TryAttach(entry);
+            }
+            ReevaluateState();
+        }
+
+        private void OnClosed(object sender, EventArgs e) {
+            _userClosed = true;
+            _installationManager.DownloadList.CollectionChanged -= OnDownloadListChanged;
+            _installationManager.PropertyChanged -= OnInstallationManagerPropertyChanged;
+            foreach (var entry in _subscribed) {
+                entry.PropertyChanged -= OnEntryPropertyChanged;
+            }
+            _subscribed.Clear();
+        }
+
+        private void OnDownloadListChanged(object sender, NotifyCollectionChangedEventArgs e) {
+            if (e.NewItems != null) {
+                foreach (ContentInstallationEntry entry in e.NewItems) {
+                    TryAttach(entry);
+                }
+            }
+            if (e.OldItems != null) {
+                foreach (ContentInstallationEntry entry in e.OldItems) {
+                    if (_subscribed.Remove(entry)) {
+                        entry.PropertyChanged -= OnEntryPropertyChanged;
+                    }
+                    _model.Entries.Remove(entry);
+                }
+            }
+            ReevaluateState();
+        }
+
+        private bool MatchesEntry(ContentInstallationEntry entry) {
+            return entry != null
+                    && _trackedSources.Contains(entry.Source)
+                    && entry.AddedDateTime >= _trackedEntriesCreatedAfter;
+        }
+
+        private void TryAttach(ContentInstallationEntry entry) {
+            if (!MatchesEntry(entry)) return;
+            if (!_model.Entries.Contains(entry)) {
+                _model.Entries.Add(entry);
+            }
+            if (_subscribed.Add(entry)) {
+                entry.PropertyChanged += OnEntryPropertyChanged;
+            }
+        }
+
+        private Control[] CreateWorkingButtons() {
+            return new Control[] {
+                    CreateExtraDialogButton(UiStrings.Toolbar_Hide, Close),
+                    CreateExtraDialogButton(AppStrings.DownloadList_Cancel, () => {
+                        foreach (var entry in _installationManager.DownloadList.Where(MatchesEntry).ToList()) {
+                            entry.CancelCommand.Execute();
+                        }
+                        Close();
+                    })
+            };
+        }
+
+        private void OnEntryPropertyChanged(object sender, PropertyChangedEventArgs e) {
+            if (e.PropertyName == nameof(ContentInstallationEntry.State)
+                    || e.PropertyName == nameof(ContentInstallationEntry.Progress)
+                    || e.PropertyName == nameof(ContentInstallationEntry.FailedMessage)) {
+                ReevaluateState();
+            }
+        }
+
+        private void OnInstallationManagerPropertyChanged(object sender, PropertyChangedEventArgs e) {
+            if (e.PropertyName == nameof(ContentInstallationManager.PostInstallAutoJoinActive)
+                    || e.PropertyName == nameof(ContentInstallationManager.PostInstallAutoJoinFailed)
+                    || e.PropertyName == nameof(ContentInstallationManager.PostInstallAutoJoinMessage)) {
+                ReevaluateState();
+            }
+        }
+
+        private void ReevaluateState() {
+            if (_userClosed) return;
+
+            var entries = _model.Entries;
+            var anyActive = entries.Count == 0 || entries.Any(x => x.State != ContentInstallationEntryState.Finished);
+            var anyFailed = entries.Any(x => x.State == ContentInstallationEntryState.Finished && !string.IsNullOrEmpty(x.FailedMessage));
+
+            if (anyActive) {
+                _model.IsRingActive = true;
+                _model.StatusKind = StatusKindValue.None;
+                _model.StatusMessage = null;
+                Buttons = CreateWorkingButtons();
+                return;
+            }
+
+            if (anyFailed) {
+                // Leave the dialog open so the player can see what went wrong; rejoin
+                // (if any) is already cancelled by ArgumentsHandler in this case.
+                _model.IsRingActive = false;
+                _model.StatusKind = StatusKindValue.Failure;
+                _model.StatusMessage = _installationManager.PostInstallAutoJoinFailed && !string.IsNullOrEmpty(_installationManager.PostInstallAutoJoinMessage)
+                        ? _installationManager.PostInstallAutoJoinMessage
+                        : AppStrings.ServerInstallProgress_FailureSummary;
+                Buttons = new[] { CloseButton };
+                return;
+            }
+
+            // Success: brief "Done" flash so the green check is actually visible, then
+            // close immediately. We DON'T wait for the rejoin chain — once installs
+            // finish, the player wants the dialog out of the way so the auto-rejoin
+            // handoff isn't visually blocked. The downloads panel still shows the
+            // "Reconnecting…" banner via PostInstallAutoJoinMessage.
+            _model.IsRingActive = false;
+            _model.StatusKind = StatusKindValue.Success;
+            _model.StatusMessage = _rejoinRequested ? AppStrings.ServerInstallProgress_DoneReconnecting : AppStrings.ServerInstallProgress_Done;
+            Buttons = Array.Empty<Control>();
+            ScheduleAutoClose();
+        }
+
+        private void ScheduleAutoClose() {
+            if (_autoCloseScheduled) return;
+            _autoCloseScheduled = true;
+
+            // Brief flash so the player actually sees the green check rather than the
+            // dialog snapping shut at the same instant the last byte lands.
+            Task.Delay(TimeSpan.FromMilliseconds(700)).ContinueWith(_ => {
+                Dispatcher.BeginInvoke(new Action(() => {
+                    if (_userClosed) return;
+                    try {
+                        Close();
+                    } catch (Exception e) {
+                        Logging.Warning(e);
+                    }
+                }));
+            });
+        }
+    }
+}

--- a/AcManager/Pages/Settings/SettingsContent.xaml
+++ b/AcManager/Pages/Settings/SettingsContent.xaml
@@ -94,6 +94,11 @@
               SelectedItem="{Binding Holder.MissingContentSearch}" DisplayMemberPath="DisplayName" />
         </DockPanel>
 
+        <CheckBox IsChecked="{Binding Holder.ServerDownloadsAutoConfirm}"
+            ToolTip="If disabled, server-driven installs will still open and download normally, but CM will wait for manual confirmation instead of auto-confirming car/track-only installs.">
+          <Label Content="Allow server-driven downloads to auto-confirm car and track installs" />
+        </CheckBox>
+
         <!-- Mega credentials -->
         <TextBlock Style="{StaticResource SettingsPanel.Heading2}" Text="{x:Static g:AppStrings.Settings_Content_MegaNzCredentials}"
             ToolTip="{x:Static g:AppStrings.Settings_Content_MegaNzCredentials_Tooltip}" />

--- a/AcManager/Tools/ArgumentsHandler.Commands.cs
+++ b/AcManager/Tools/ArgumentsHandler.Commands.cs
@@ -11,6 +11,7 @@ using System.Web;
 using System.Windows;
 using AcManager.CustomShowroom;
 using AcManager.Internal;
+using AcManager.Pages.Dialogs;
 using AcManager.Pages.Drive;
 using AcManager.Pages.Miscellaneous;
 using AcManager.Tools.ContentInstallation;
@@ -216,10 +217,88 @@ namespace AcManager.Tools {
                             ModsWebBrowser.PrepareForCommand(urls, custom.Params.GetValues(@"websiteData") ?? new string[0]);
                         }
 
-                        return (await urls.Select(
-                                x => ContentInstallationManager.Instance.InstallAsync(x, new ContentInstallationParams(true) {
-                                    CarId = custom.Params.Get(@"car")
-                                })).WhenAll()).Any() ? ArgumentHandleResult.Successful : ArgumentHandleResult.Failed;
+                        var installationManager = ContentInstallationManager.Instance;
+                        // Always clear any previous auto-rejoin banner up-front so a stale
+                        // "Rejoined the server" / failure message from a prior install doesn't
+                        // sit on top of an unrelated new download.
+                        installationManager.ClearPostInstallAutoJoinState();
+                        var rejoin = custom.Params.GetFlag("rejoin");
+                        var ip = custom.Params.Get(@"ip")?.Trim();
+                        var httpPort = FlexibleParser.TryParseInt(custom.Params.Get(@"httpPort"));
+                        var carId = custom.Params.Get(@"car")?.Trim();
+                        var skinId = custom.Params.Get(@"skin")?.Trim();
+                        var password = custom.Params.Get(@"plainPassword");
+                        var encryptedPassword = custom.Params.Get(@"password");
+
+                        if (string.IsNullOrWhiteSpace(password) && !string.IsNullOrWhiteSpace(encryptedPassword)
+                                && !string.IsNullOrWhiteSpace(ip) && httpPort.HasValue) {
+                            password = OnlineServer.DecryptSharedPassword(ip, httpPort.Value, encryptedPassword);
+                        }
+
+                        var autoRejoinReady = rejoin && !string.IsNullOrWhiteSpace(ip) && httpPort.HasValue
+                                && !string.IsNullOrWhiteSpace(carId) && !string.IsNullOrWhiteSpace(skinId);
+
+                        if (rejoin) {
+                            if (autoRejoinReady) {
+                                // Suppress the "Practice / Try again / Replay" GameDialog that would
+                                // otherwise pop up when AC closes for the content handoff. The flag
+                                // is one-shot and auto-expires, so a stale rejoin never swallows a
+                                // legit race result later on.
+                                GameDialog.SkipNextResultUntil = DateTime.UtcNow.AddSeconds(30);
+                                installationManager.SetPostInstallAutoJoinState(AppStrings.Arguments_AutoRejoinEnabled_State);
+                                Toast.Show(AppStrings.Arguments_AutoRejoinEnabled_Title, AppStrings.Arguments_AutoRejoinEnabled_Message);
+                            } else {
+                                installationManager.SetPostInstallAutoJoinState(
+                                        AppStrings.Arguments_AutoRejoinSkipped_State, true);
+                                Toast.Show(AppStrings.Arguments_AutoRejoinSkipped_Title, AppStrings.Arguments_AutoRejoinSkipped_Message);
+                            }
+                        }
+
+                        var autoConfirm = custom.Params.GetFlag("autoconfirm");
+                        var installStartedAt = DateTime.Now;
+
+                        // For server-driven installs (auto-confirm and/or auto-rejoin) surface a small
+                        // modal popup so the player gets a focused view of the in-flight downloads
+                        // without having to dig into the downloads panel. Open it with the dialog API
+                        // instead of plain Show() so it is actually modal while visible. Hide just closes
+                        // the popup; the install keeps running and the downloads panel still reflects state.
+                        if (autoConfirm || rejoin) {
+                            try {
+                                new ServerInstallProgressDialog(urls, rejoin, autoConfirm, installStartedAt).ShowDialogAsync().Ignore();
+                            } catch (Exception dialogException) {
+                                Logging.Warning("Failed to open ServerInstallProgressDialog: " + dialogException);
+                            }
+                        }
+
+                        var results = (await urls.Select(
+                                x => installationManager.InstallAsync(x, new ContentInstallationParams(true) {
+                                    CarId = custom.Params.Get(@"car"),
+                                    AutoConfirmServerInstall = autoConfirm
+                                })).WhenAll()).ToArray();
+
+                        var anySucceeded = results.Any(x => x);
+                        var allSucceeded = results.Length > 0 && results.All(x => x);
+
+                        if (autoRejoinReady) {
+                            if (!allSucceeded) {
+                                installationManager.SetPostInstallAutoJoinState(
+                                        AppStrings.Arguments_AutoRejoinCancelled_State, true);
+                                Toast.Show(AppStrings.Arguments_AutoRejoinCancelled_Title, AppStrings.Arguments_AutoRejoinCancelled_Message);
+                            } else {
+                                installationManager.SetPostInstallAutoJoinState(AppStrings.Arguments_AutoRejoinRejoining_State);
+                                try {
+                                    await AutoJoinInvitation(ip, httpPort.Value, carId, skinId, password);
+                                    installationManager.SetPostInstallAutoJoinState(AppStrings.Arguments_AutoRejoinRejoined_State);
+                                    Toast.Show(AppStrings.Arguments_AutoRejoinReconnected_Title, AppStrings.Arguments_AutoRejoinReconnected_Message);
+                                } catch (Exception e) {
+                                    installationManager.SetPostInstallAutoJoinState(
+                                            AppStrings.Arguments_AutoRejoinFailed_State, true);
+                                    NonfatalError.NotifyBackground("Automatic rejoin failed", e.Message, e);
+                                }
+                            }
+                        }
+
+                        return anySucceeded ? ArgumentHandleResult.Successful : ArgumentHandleResult.Failed;
 
                     case "importwebsite":
                         return await ProcessImportWebsite(custom.Params.GetValues(@"data") ?? new string[0]);

--- a/AcManager/Tools/ArgumentsHandler.Race.cs
+++ b/AcManager/Tools/ArgumentsHandler.Race.cs
@@ -169,11 +169,12 @@ namespace AcManager.Tools {
             }
         }
 
-        public static async Task JoinInvitation([NotNull] string ip, int port, [CanBeNull] string password) {
+        private static async Task<Tuple<OnlineSourceWrapper, ServerEntry>> LoadInvitationServerAsync([NotNull] string ip, int httpPort,
+                [CanBeNull] string password) {
             OnlineManager.EnsureInitialized();
 
             var list = OnlineManager.Instance.List;
-            var source = new FakeSource(ip, port);
+            var source = new FakeSource(ip, httpPort);
             var wrapper = new OnlineSourceWrapper(list, source);
 
             ServerEntry server;
@@ -186,11 +187,21 @@ namespace AcManager.Tools {
                 if (server == null) {
                     throw new Exception(@"Unexpected");
                 }
+
+                await server.Update(ServerEntry.UpdateMode.Lite, fast: true);
             }
 
             if (password != null) {
                 server.Password = password;
             }
+
+            return Tuple.Create(wrapper, server);
+        }
+
+        public static async Task JoinInvitation([NotNull] string ip, int port, [CanBeNull] string password) {
+            var loaded = await LoadInvitationServerAsync(ip, port, password);
+            var wrapper = loaded.Item1;
+            var server = loaded.Item2;
 
             var content = new OnlineServer(server) {
                 Margin = new Thickness(0, 0, 0, -38),
@@ -224,6 +235,32 @@ namespace AcManager.Tools {
 
             dlg.ShowDialog();
             await wrapper.ReloadAsync(true);
+        }
+
+        public static async Task AutoJoinInvitation([NotNull] string ip, int httpPort, [NotNull] string carId, [NotNull] string skinId,
+                [CanBeNull] string password) {
+            var loaded = await LoadInvitationServerAsync(ip, httpPort, password);
+            var wrapper = loaded.Item1;
+            var server = loaded.Item2;
+
+            try {
+                var selectedCar = server.Cars?.GetByIdOrDefault(carId, StringComparison.OrdinalIgnoreCase);
+                if (selectedCar == null) {
+                    throw new InformativeException($"Car “{carId}” is missing");
+                }
+
+                var selectedSkin = selectedCar.CarObject?.GetSkinById(skinId);
+                if (selectedSkin == null) {
+                    throw new InformativeException($"Car skin “{skinId}” is missing");
+                }
+
+                server.SetSelectedCarEntry(selectedCar);
+                selectedCar.AvailableSkin = selectedSkin;
+
+                await server.JoinCommand.ExecuteAsync(ServerEntry.ForceJoin);
+            } finally {
+                await wrapper.ReloadAsync(true);
+            }
         }
 
         private static async Task<ArgumentHandleResult> ProcessRaceOnlineJoin(NameValueCollection p) {

--- a/AcManager/UserControls/InstallAdditionalContentList.xaml
+++ b/AcManager/UserControls/InstallAdditionalContentList.xaml
@@ -421,6 +421,24 @@
     <mui:PlaceholderTextBlock mui:Switch.When="0" Placeholder="{x:Static g:AppStrings.DownloadList_NoActiveDownloads}" Margin="8 0 0 8"
         VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType=uc:InstallAdditionalContentList}}" />
     <DockPanel>
+      <mui:BooleanSwitch DockPanel.Dock="Top" Value="{Binding PostInstallAutoJoinActive, Source={x:Static t:ContentInstallationManager.Instance}}">
+        <c:MessageBlock Margin="0 0 0 20">
+          <DockPanel>
+            <TextBlock DockPanel.Dock="Top" Text="Automatic rejoin" FontWeight="SemiBold" Margin="0 0 0 6" />
+            <TextBlock Text="{Binding PostInstallAutoJoinMessage, Source={x:Static t:ContentInstallationManager.Instance}}" TextWrapping="Wrap">
+              <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                  <Style.Triggers>
+                    <DataTrigger Binding="{Binding PostInstallAutoJoinFailed, Source={x:Static t:ContentInstallationManager.Instance}}" Value="True">
+                      <Setter Property="Foreground" Value="{DynamicResource Error}" />
+                    </DataTrigger>
+                  </Style.Triggers>
+                </Style>
+              </TextBlock.Style>
+            </TextBlock>
+          </DockPanel>
+        </c:MessageBlock>
+      </mui:BooleanSwitch>
       <mui:BooleanSwitch DockPanel.Dock="Top" Value="{Binding Plugins.IsReady, Converter={StaticResource InvertBooleanConverter}}">
         <c:MessageBlock Margin="0 0 0 20">
           <DockPanel>


### PR DESCRIPTION
Adds support for server-driven content installs with a compact modal progress dialog and automatic rejoin once installation finishes. The goal is to make the CM handoff smoother when a server asks the player to download required content, especially for car/track installs where the server already knows the correct join context, while still requiring explicit confirmation for less trusted content types.

### **Changes:**
857cd93e + c544918:

- AcManager/Pages/Dialogs/ServerInstallProgressDialog.xaml and AcManager/Pages/Dialogs/ServerInstallProgressDialog.xaml.cs add a compact modal progress dialog for server-triggered installs, with per-item progress, success/failure states, a Hide/Cancel flow, and a manual confirmation path for non-car/track installs.
- AcManager/Tools/ArgumentsHandler.Commands.cs extends acmanager://install handling with the server-driven install UI, auto-confirm support for safe installs, rejoin state handling, and automatic rejoin after successful installation.
- AcManager/Tools/ArgumentsHandler.Race.cs uses the automatic invitation join path for reconnecting with the selected server/car/skin context after install completes.
- AcManager/Pages/Dialogs/GameDialog.xaml.cs suppresses the post-AC-close results dialog for install handoff flows so Content Manager does not show an irrelevant Practice / Try again / Replay window.
- AcManager.Tools/ContentInstallation/ContentInstallationParams.cs and AcManager.Tools/ContentInstallation/ContentInstallationEntry.cs add support for auto-confirming safe server-driven installs only when detected content is limited to cars and tracks, while leaving other content types on an explicit confirmation step.
- AcManager.Tools/ContentInstallation/ContentInstallationManager.cs adds post-install auto-rejoin state tracking used by the downloads UI and the new dialog.
- AcManager/UserControls/InstallAdditionalContentList.xaml shows the auto-rejoin status in the downloads panel.
- AcManager/AppStrings.resx and AcManager/AppStrings.Designer.cs add the new user-facing strings used by the server install/rejoin flow, including the manual-confirmation warning and confirmation button text.
- AcManager/AcManager.csproj includes the new dialog files.

**Notes:**

- Car and track installs can be auto-confirmed when the server provides the full rejoin context.
- Non-car/track installs are not auto-confirmed; the dialog now shows a warning and requires the player to click Confirm.
- The dialog is modal while visible, tracks only entries created by the current install request, briefly shows success before closing, and leaves failures visible so the player can see what went wrong.
- About the server download UI: I have even less experience in UI work than in general coding, so I focused on getting the flow working and reasonably clean first. It should already be acceptable, but feel free to polish it further to better match CM’s general look.