### PR TITLE
Add a new server sorting method, Filtered Connected Drivers

### DIFF
--- a/AcManager.Tools/Helpers/SettingsHolder.Drive.cs
+++ b/AcManager.Tools/Helpers/SettingsHolder.Drive.cs
@@ -749,6 +749,22 @@ namespace AcManager.Tools.Helpers {
                 }
             }
 
+            private string _filteredConnectedDrivers;
+            public string FilteredConnectedDrivers
+            {
+                get => _filteredConnectedDrivers
+                        ?? (_filteredConnectedDrivers = ValuesStorage.Get("Settings.DriveSettings.FilteredConnectedDrivers", PlayerName));
+                set
+                {
+                    value = value?.Trim();
+                    if (Equals(value, _filteredConnectedDrivers)) return;
+                    _filteredConnectedDrivers = value;
+                    ValuesStorage.Set("Settings.DriveSettings.FilteredConnectedDrivers", value);
+                    OnPropertyChanged();
+                }
+            }
+            
+
             private bool? _loadAssistsWithQuickDrivePreset;
 
             public bool LoadAssistsWithQuickDrivePreset {

--- a/AcManager.Tools/Helpers/SettingsHolder.Drive.cs
+++ b/AcManager.Tools/Helpers/SettingsHolder.Drive.cs
@@ -753,7 +753,7 @@ namespace AcManager.Tools.Helpers {
             public string FilteredConnectedDrivers
             {
                 get => _filteredConnectedDrivers
-                        ?? (_filteredConnectedDrivers = ValuesStorage.Get("Settings.DriveSettings.FilteredConnectedDrivers", PlayerName));
+                        ?? (_filteredConnectedDrivers = ValuesStorage.Get("Settings.DriveSettings.FilteredConnectedDrivers"));
                 set
                 {
                     value = value?.Trim();

--- a/AcManager.Tools/Helpers/SettingsHolder.Drive.cs
+++ b/AcManager.Tools/Helpers/SettingsHolder.Drive.cs
@@ -753,7 +753,7 @@ namespace AcManager.Tools.Helpers {
             public string FilteredConnectedDrivers
             {
                 get => _filteredConnectedDrivers
-                        ?? (_filteredConnectedDrivers = ValuesStorage.Get("Settings.DriveSettings.FilteredConnectedDrivers"));
+                        ?? (_filteredConnectedDrivers = ValuesStorage.Get<string>("Settings.DriveSettings.FilteredConnectedDrivers"));
                 set
                 {
                     value = value?.Trim();

--- a/AcManager/AppStrings.Designer.cs
+++ b/AcManager/AppStrings.Designer.cs
@@ -11371,6 +11371,44 @@ namespace AcManager {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Filtered Connected Drivers:.
+        /// </summary>
+        public static string Settings_Online_Filtered_Connected_Drivers {
+            get {
+                return ResourceManager.GetString("Settings_Online_Filtered_Connected_Drivers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to VIP Slot
+        ///Reserved
+        ///Not Connected.
+        /// </summary>
+        public static string Settings_Online_Filtered_Connected_Drivers_Placeholder {
+            get {
+                return ResourceManager.GetString("Settings_Online_Filtered_Connected_Drivers_Placeholder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List of strings to search for driver names that should be filtered, separated by new-lines.
+        /// </summary>
+        public static string Settings_Online_Filtered_Connected_Drivers_Title {
+            get {
+                return ResourceManager.GetString("Settings_Online_Filtered_Connected_Drivers_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If a server has a driver that matches the string in the pattern, this driver doesn&apos;t count in the sorting of Filtered Connected Drivers. This means if server has 24 people, but all of them contain any pattern from the list (e.g. VIP Slot, Reserved, Unconnected), then this server will not be appearing at the top of server list..
+        /// </summary>
+        public static string Settings_Online_Filtered_Connected_Drivers_Tooltip {
+            get {
+                return ResourceManager.GetString("Settings_Online_Filtered_Connected_Drivers_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix names:.
         /// </summary>
         public static string Settings_Online_FixNames {

--- a/AcManager/AppStrings.Designer.cs
+++ b/AcManager/AppStrings.Designer.cs
@@ -7729,6 +7729,15 @@ namespace AcManager {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Filtered connected drivers.
+        /// </summary>
+        public static string Online_Sorting_FilteredConnectedDrivers {
+            get {
+                return ResourceManager.GetString("Online_Sorting_FilteredConnectedDrivers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
         public static string Online_Sorting_Name {

--- a/AcManager/AppStrings.resx
+++ b/AcManager/AppStrings.resx
@@ -5010,4 +5010,7 @@ Not Connected</value>
     <data name="Settings_Online_Filtered_Connected_Drivers_Title" xml:space="preserve">
         <value>List of strings to search for driver names that should be filtered, separated by new-lines</value>
     </data>
+    <data name="Online_Sorting_FilteredConnectedDrivers" xml:space="preserve">
+        <value>Filtered connected drivers</value>
+    </data>
 </root>

--- a/AcManager/AppStrings.resx
+++ b/AcManager/AppStrings.resx
@@ -4996,4 +4996,18 @@ Content Manager [url="/Pages/About/License.xaml|_top"]License[/url].</value>
     <data name="UserChampionships_CreateNew" xml:space="preserve">
         <value>Create new</value>
     </data>
+    <data name="Settings_Online_Filtered_Connected_Drivers_Tooltip" xml:space="preserve">
+        <value>If a server has a driver that matches the string in the pattern, this driver doesn't count in the sorting of Filtered Connected Drivers. This means if server has 24 people, but all of them contain any pattern from the list (e.g. VIP Slot, Reserved, Unconnected), then this server will not be appearing at the top of server list.</value>
+    </data>
+    <data name="Settings_Online_Filtered_Connected_Drivers_Placeholder" xml:space="preserve">
+        <value>VIP Slot
+Reserved
+Not Connected</value>
+    </data>
+    <data name="Settings_Online_Filtered_Connected_Drivers" xml:space="preserve">
+        <value>Filtered Connected Drivers:</value>
+    </data>
+    <data name="Settings_Online_Filtered_Connected_Drivers_Title" xml:space="preserve">
+        <value>List of strings to search for driver names that should be filtered, separated by new-lines</value>
+    </data>
 </root>

--- a/AcManager/Pages/Drive/Online.SortingModes.cs
+++ b/AcManager/Pages/Drive/Online.SortingModes.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections;
+using System.Linq;
 using AcManager.Tools.Helpers;
 using AcManager.Tools.Managers.Online;
+using AcTools.Utils.Helpers;
 using FirstFloor.ModernUI.Helpers;
 using FirstFloor.ModernUI.Presentation;
 using JetBrains.Annotations;
@@ -82,6 +84,38 @@ namespace AcManager.Pages.Drive {
             }
         }
 
+        private class SortingFilteredConnectedDriversCount : ServerEntrySorter
+        {
+            public override int Compare(ServerEntry x, ServerEntry y)
+            {
+                var filteredPatterns = SettingsHolder.Drive.FilteredConnectedDrivers
+                    .Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(val => val.ToLowerInvariant());
+
+                var xFilteredDriversCount = x.CurrentDrivers?.Count(driver => {
+                    return !filteredPatterns.Any(filteredPattern =>
+                    {
+                        return driver.Name.ToLower().Contains(filteredPattern);
+                    });
+                }) ?? x.ConnectedDrivers;
+
+                var yFilteredDriversCount = y.CurrentDrivers?.Count(driver => {
+                    return !filteredPatterns.Any(filteredPattern =>
+                    {
+                        return driver.Name.ToLower().Contains(filteredPattern);
+                    });
+                }) ?? y.ConnectedDrivers;
+
+                var dif = -xFilteredDriversCount.CompareTo(yFilteredDriversCount);
+                return dif == 0 ? string.Compare(x.SortingName, y.SortingName, StringComparison.Ordinal) : dif;
+            }
+
+            public override bool IsAffectedBy(string propertyName)
+            {
+                return propertyName == nameof(ServerEntry.ConnectedDrivers);
+            }
+        }
+
         private class SortingCapacityCount : ServerEntrySorter {
             public override int Compare(ServerEntry x, ServerEntry y) {
                 var dif = -x.Capacity.CompareTo(y.Capacity);
@@ -125,6 +159,8 @@ namespace AcManager.Pages.Drive {
                     return new SortingDriversCount();
                 case "connected":
                     return new SortingConnectedDriversCount();
+                case "filteredConnected":
+                    return new SortingFilteredConnectedDriversCount();
                 case "capacity":
                     return new SortingCapacityCount();
                 case "cars":
@@ -146,6 +182,7 @@ namespace AcManager.Pages.Drive {
             new SettingEntry("favourites", AppStrings.Online_Sorting_Favourites),
             new SettingEntry("drivers", AppStrings.Online_Sorting_Drivers),
             new SettingEntry("connected", AppStrings.Online_Sorting_ConnectedDrivers),
+            new SettingEntry("filteredConnected", AppStrings.Online_Sorting_FilteredConnectedDrivers),
             new SettingEntry("capacity", AppStrings.Online_Sorting_Capacity),
             new SettingEntry("cars", AppStrings.Online_Sorting_CarsNumber),
             new SettingEntry("ping", AppStrings.Online_Sorting_Ping)

--- a/AcManager/Pages/Settings/SettingsOnline.xaml
+++ b/AcManager/Pages/Settings/SettingsOnline.xaml
@@ -258,6 +258,19 @@
             ToolTip="You might want to enable this option if you run Content Manager fullscreen. Also, just in case, shortcuts Alt+F1…Alt+F5 allow you to switch between those tabs quickly.">
           <Label Content="Combine together main, assists, conditions and sessions tabs" />
         </CheckBox>-->
+
+        <TextBlock Style="{StaticResource SettingsPanel.Heading2}" Text="{x:Static g:AppStrings.Settings_Online_Filtered_Connected_Drivers}" />
+        <Label ToolTip="{x:Static g:AppStrings.Settings_Online_Filtered_Connected_Drivers_Tooltip}" Content="{x:Static g:AppStrings.Settings_Online_Filtered_Connected_Drivers_Title}" />
+        <mui:BetterTextBox 
+          TextWrapping="Wrap"
+          AcceptsReturn="True"
+          MinLines="3"
+          VerticalScrollBarVisibility="Auto"
+          HorizontalScrollBarVisibility="Disabled"
+          Text="{Binding Drive.FilteredConnectedDrivers}" 
+          Placeholder="{x:Static g:AppStrings.Settings_Online_Filtered_Connected_Drivers_Placeholder}" 
+          IsEnabled="{Binding Drive.FilteredConnectedDrivers}" />
+        
       </StackPanel>
 
     </mui:SpacingUniformGrid>


### PR DESCRIPTION
In the server list of Content Manager, you can already sort servers by Connected Drivers.

However, nowadays there is a problem where server owners have some users be permanently listed as connected on the server, while not actually being connected to them, as a form of reserving a slot for a player. This causes the server to be displayed as if has 5 players on it, it's sorted accordingly, however, if you try to join it, you will find that the server is actually empty.

<img width="400" alt="before" src="https://github.com/user-attachments/assets/a9da9cbd-a20b-4fe3-93b1-a0eaefb0b598" />

I also believe that the mechanisms involved here are not related in any way to the booking system - these phantom drivers are displayed literally as if they are random players already racing on the server, when they are not.

This limits the usefulness of Connected Drivers sorting because the core intent is to find servers that have players right now that you can race against.

I propose adding a new setting to Online settings of Content Manager, Filtered Connected Drivers and a new sorting mode. 
- In settings, there will be a multiline text box that allows the user to specify a list of patterns, separated by newline.

<img width="400" alt="settings" src="https://github.com/user-attachments/assets/d9ae29d8-c97c-4929-ac0c-c2bf98f3880f" />

- In server list, a new sorting mode is available, Filtered Connected Drivers

<img width="400" alt="new sorting" src="https://github.com/user-attachments/assets/8a5b2dcb-1544-4649-a7c6-d84904046d8c" />

- The new sorting mode counts the drivers per server, but it excludes any driver whose name contains any pattern from the list of patterns specified in the settings at `Settings -> Content Manager -> Online -> Filtered Connected Drivers`.

Example:
- 3 servers
  - A, with 5 drivers: Steve, Mark, Alice, Nick, Gabe
  - B, with 3 drivers: Reserved Slot, Reserved Slot, Reserved Slot
  - C, with 1 driver: Bob 
- If the sorting mode is Connected Drivers, we will see the order of servers: 
  - ABC, 5-3-1 drivers
- But with this new feature, we can set the value of `Settings -> Content Manager -> Online -> Filtered Connected Drivers` to 

```
Reserved Slot
VIP
Not Connected
```
- And then in Filtered Connected Drivers sorting mode, we will see the order of servers:
  - ACB, 5-1-3
  - Because all of 3drivers in server B have matched to any of the lines of the `Settings -> Content Manager -> Online -> Filtered Connected Drivers`, effectively causing it to count as having "0 drivers" in the sorting algorithm.
  
<img width="400" alt="after" src="https://github.com/user-attachments/assets/5ba69838-6646-48a2-b21c-141d3e8d02a1" />

The default value for the filtering list is not provided.

Also the solution is a bit inefficient because it recalculates the driver list on every comparator call between 2 server instances, meaning that there is up to an exponential recalculation of filtered driver names in relation to the number of servers to sort. A good way to improve this is to make the filtered list of drivers count be stored on `ServerEntry`, however, this will mean updating every server entry with the new filter list every time we go back to the server list, I imagine. I can do that too if necessary.