### PR TITLE
Fix app unresponsive when loading images

### DIFF
--- a/FirstFloor.ModernUI/Windows/Controls/BetterImage.cs
+++ b/FirstFloor.ModernUI/Windows/Controls/BetterImage.cs
@@ -77,7 +77,7 @@ namespace FirstFloor.ModernUI.Windows.Controls {
         /// If image’s size is smaller than this, it will be decoded in the UI thread.
         /// Doesn’t do anything if OptionDecodeImageSync is true.
         /// </summary>
-        public static int OptionDecodeImageSyncThreshold = 0; // 0 KB
+        public static int OptionDecodeImageSyncThreshold = 50 * 1000; // 50 KB
 
         // public static int OptionDecodeImageSyncThreshold = 50; // 50 KB
 
@@ -768,7 +768,7 @@ namespace FirstFloor.ModernUI.Windows.Controls {
                         downsized = true;
                     }
 
-                    bi.CreateOptions = BitmapCreateOptions.None;
+                    bi.CreateOptions = BitmapCreateOptions.IgnoreColorProfile;
                     bi.CacheOption = BitmapCacheOption.OnLoad;
                     bi.StreamSource = stream;
                     bi.EndInit();
@@ -1336,13 +1336,13 @@ namespace FirstFloor.ModernUI.Windows.Controls {
             }
 
             int w = b.PixelWidth, h = b.PixelHeight, s = (w * b.Format.BitsPerPixel + 7) / 8;
-            if (w > 800 || h > 450) {
+            var data = _transparentCropData.Value;
+            if ((long)s * h > data.Length) {
                 Logging.Warning($"Image is too large to crop: {w}×{h}, tag: {tag}");
                 left = top = right = bottom = 0;
                 return true;
             }
 
-            var data = _transparentCropData.Value;
             b.CopyPixels(data, s, 0);
 
             var k = b.Format.Masks.ElementAtOrDefault(0).Mask;

--- a/FirstFloor.ModernUI/Windows/Controls/BetterImage.cs
+++ b/FirstFloor.ModernUI/Windows/Controls/BetterImage.cs
@@ -77,7 +77,7 @@ namespace FirstFloor.ModernUI.Windows.Controls {
         /// If image’s size is smaller than this, it will be decoded in the UI thread.
         /// Doesn’t do anything if OptionDecodeImageSync is true.
         /// </summary>
-        public static int OptionDecodeImageSyncThreshold = 50 * 1000; // 50 KB
+        public static int OptionDecodeImageSyncThreshold = 0; // 0 KB
 
         // public static int OptionDecodeImageSyncThreshold = 50; // 50 KB
 


### PR DESCRIPTION
Right now there are several cases in the launcher where the app becomes unresponsive:

- selecting a server
- opening Media page for the first time
- opening Results page for the first time
- randomly when scrolling around in the cars list

I have profiled the application in Visual Studio, and I have found out that most of the CPU time of the program has been taken by **BetterImage.cs** calling `BitmapImage.EndInit()`

**BetterImage.cs** tries to decode images less than 50 KB synchronously on the UI thread, however what happens is that `BitmapImage.EndInit()` underneath calls `FinalizeCreation()`, which inside has logic that causes the color profile of the source image to be converted via a call to `new ColorConvertedBitmap` which under the hood calls `UnsafeNativeMethods.WICColorTransform.Initialize`, which is implemented by a blocking interop service call. This procedure ends up being very slow, and because it's on main thread, this causes UI to stutter.

<img width="800" alt="endinit perf" src="https://github.com/user-attachments/assets/ef68958b-7d3d-47bb-a155-f7d7dacd2447" />

My proposed solution is to reduce altogether the work needed by disabling the color profile conversion via providing `CreateOptions = BitmapCreateOptions.IgnoreColorProfile`. 

This has caused some images to cause an exception in the **BetterImage.cs** automatic cropping functionality available via DependencyProperty `CropTransparentAreas`. There was an invalid assumption of what the characteristics of an image were supposed to be in order to fit into a fixed size array. I have fixed it by checking directly against the size of the buffer rather than the width and stride values.

After the fix, the navigation in the app is instantaneous, there is no more unresponsiveness. Profiling after the fix shows drastic fall in CPU usage and the Hot Path is now nothing significant.

Before the fix:

<img width="800" alt="CPU usage before" src="https://github.com/user-attachments/assets/9aacdcc1-166f-4eba-a138-c3b85fcd1b91" />

After the fix:

<img width="800" alt="profile after fix" src="https://github.com/user-attachments/assets/bd4f1874-a336-4781-800f-8fc4960ded58" />

Video:

Before:

https://github.com/user-attachments/assets/e68d0d55-1b2d-4a5b-ad52-f299739e2e2d

After:

https://github.com/user-attachments/assets/b6d3792c-53a5-4fee-a4dc-cf30b3dd5ddd